### PR TITLE
Use searchTable to store query meta data

### DIFF
--- a/cmd/proxy/server.go
+++ b/cmd/proxy/server.go
@@ -60,6 +60,12 @@ func main() {
 				Usage:       "AWS region",
 				Destination: &args.Region,
 			},
+			&cli.StringFlag{
+				Name:        "search-table",
+				Aliases:     []string{"s"},
+				Usage:       "Search DynamoDB table name",
+				Destination: &args.SearchTableName,
+			},
 
 			// Optional parameters
 			&cli.StringFlag{

--- a/lambda/apiHandler/main.go
+++ b/lambda/apiHandler/main.go
@@ -27,6 +27,7 @@ func main() {
 		MessageTableName: os.Getenv("MESSAGE_TABLE_NAME"),
 		OutputPath:       fmt.Sprintf("s3://%s/%soutput", os.Getenv("S3_BUCKET"), os.Getenv("S3_PREFIX")),
 		Region:           os.Getenv("AWS_REGION"),
+		SearchTableName:  os.Getenv("SEARCH_TABLE_NAME"),
 	}
 
 	gin.SetMode(gin.ReleaseMode)

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -10,6 +10,7 @@ type Error interface {
 	Error() string
 	Code() int
 	Message() string
+	Cause() error
 }
 
 type baseError struct {
@@ -24,6 +25,10 @@ func (x *baseError) Message() string {
 	}
 
 	return x.Err.Error()
+}
+
+func (x *baseError) Cause() error {
+	return x.Err
 }
 
 type userError struct{ baseError }

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -8,6 +8,7 @@ var (
 type LogFilter logFilter
 type LogDataSet logDataSet
 type LogQueue logQueue
+type SearchID searchID
 
 func ExtractLogs(ch chan *LogQueue, filter LogFilter) (*LogDataSet, error) {
 	pipe := make(chan *logQueue)

--- a/pkg/api/get_search.go
+++ b/pkg/api/get_search.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type GetSearchResponse struct {
+	ID       searchID        `json:"search_id"`
+	MetaData *searchMetaData `json:"metadata"`
+}
+
+func (x MinervaHandler) getMetaData(id searchID) (*searchMetaData, Error) {
+	repo := x.newSearchRepo()
+
+	item, err := repo.get(id)
+	if err != nil {
+		return nil, wrapSystemError(err, http.StatusInternalServerError, "Fail to access DynamoDB")
+	} else if item == nil {
+		return nil, newUserErrorf(http.StatusNotFound, "Search result is not found: %s", id)
+	}
+
+	if item.Status == statusRunning {
+		status, err := getAthenaQueryStatus(x.Region, item.AthenaQueryID)
+		if err != nil {
+			return nil, err
+		}
+
+		if status.Status != statusRunning {
+			item.CompletedAt = status.CompletedAt
+			item.Status = toQueryStatus(status.Status)
+			item.OutputPath = status.OutputPath
+			item.ScannedSize = status.ScannedSize
+
+			if err := repo.put(item); err != nil {
+				return nil, wrapSystemError(err, http.StatusInternalServerError, "Fail to update search item")
+			}
+		}
+	}
+
+	return &searchMetaData{
+		Status:         item.Status,
+		Query:          item.Query,
+		ElapsedSeconds: item.getElapsedSeconds(),
+		StartTime:      item.StartTime.Unix(),
+		EndTime:        item.EndTime.Unix(),
+		SubmittedTime:  *item.CreatedAt,
+
+		outputPath: item.OutputPath,
+	}, nil
+}
+
+func (x *MinervaHandler) GetSearch(c *gin.Context) (*Response, Error) {
+	id := searchID(c.Param("search_id"))
+
+	meta, err := x.getMetaData(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		Code: http.StatusOK,
+		Message: GetSearchResponse{
+			ID:       id,
+			MetaData: meta,
+		},
+	}, nil
+}

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -13,6 +13,7 @@ type Response struct {
 
 type Handler interface {
 	ExecSearch(c *gin.Context) (*Response, Error)
+	GetSearch(c *gin.Context) (*Response, Error)
 	GetSearchLogs(c *gin.Context) (*Response, Error)
 	GetSearchTimeSeries(c *gin.Context) (*Response, Error)
 }
@@ -22,7 +23,12 @@ type MinervaHandler struct {
 	IndexTableName   string
 	MessageTableName string
 	OutputPath       string
+	SearchTableName  string
 	Region           string
+}
+
+func (x *MinervaHandler) newSearchRepo() searchRepository {
+	return newSearchRepoDynamoDB(x.Region, x.SearchTableName)
 }
 
 // Handler is handler interface

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -10,31 +10,31 @@ import (
 	"github.com/google/uuid"
 )
 
-type queryMeta struct {
+type searchMeta struct {
 	query  string
 	ExecAt time.Time
 }
 
 type MockHandler struct {
-	mapQueryID map[string]*queryMeta
-	LogTotal   int
-	LogLimit   int
+	mapSearchID map[searchID]*searchMeta
+	LogTotal    int
+	LogLimit    int
 }
 
 func NewMockHandler() *MockHandler {
 	return &MockHandler{
-		mapQueryID: make(map[string]*queryMeta),
+		mapSearchID: make(map[searchID]*searchMeta),
 	}
 }
 
 func (x *MockHandler) ExecSearch(c *gin.Context) (*Response, Error) {
-	queryID := uuid.New().String()
-	x.mapQueryID[queryID] = &queryMeta{
+	id := searchID(uuid.New().String())
+	x.mapSearchID[id] = &searchMeta{
 		ExecAt: time.Now(),
 	}
 
 	return &Response{201, &ExecSearchResponse{
-		QueryID: queryID,
+		SearchID: searchID(id),
 	}}, nil
 }
 
@@ -123,13 +123,13 @@ func newLogStream(max int) chan *logQueue {
 }
 
 func (x *MockHandler) GetSearchLogs(c *gin.Context) (*Response, Error) {
-	queryID := c.Param("query_id")
+	id := searchID(c.Param("search_id"))
 
 	resp := GetSearchLogsResponse{
-		QueryID: queryID,
+		ID: id,
 	}
 
-	q, ok := x.mapQueryID[queryID]
+	q, ok := x.mapSearchID[id]
 	if !ok {
 		Logger.Error("invalid query ID")
 		return &Response{404, "query not found"}, nil
@@ -165,5 +165,9 @@ func (x *MockHandler) GetSearchLogs(c *gin.Context) (*Response, Error) {
 }
 
 func (x *MockHandler) GetSearchTimeSeries(c *gin.Context) (*Response, Error) {
+	return nil, nil
+}
+
+func (x *MockHandler) GetSearch(c *gin.Context) (*Response, Error) {
 	return nil, nil
 }

--- a/pkg/api/route.go
+++ b/pkg/api/route.go
@@ -14,11 +14,15 @@ func SetupRoute(r *gin.RouterGroup, handler Handler) {
 		resp, err := handler.ExecSearch(c)
 		sendResponse(c, resp, err)
 	})
-	r.GET("/search/:query_id/logs", func(c *gin.Context) {
+	r.GET("/search/:search_id", func(c *gin.Context) {
 		resp, err := handler.GetSearchLogs(c)
 		sendResponse(c, resp, err)
 	})
-	r.GET("/search/:query_id/timeseries", func(c *gin.Context) {
+	r.GET("/search/:search_id/logs", func(c *gin.Context) {
+		resp, err := handler.GetSearchLogs(c)
+		sendResponse(c, resp, err)
+	})
+	r.GET("/search/:search_id/timeseries", func(c *gin.Context) {
 		resp, err := handler.GetSearchTimeSeries(c)
 		sendResponse(c, resp, err)
 	})

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/guregu/dynamo"
+	"github.com/pkg/errors"
+)
+
+type searchID string
+
+type searchMetaData struct {
+	Status         queryStatus `json:"status"`
+	SubmittedTime  time.Time   `json:"submitted_time"`
+	ElapsedSeconds float64     `json:"elapsed_seconds"`
+	Query          []query     `json:"query"`
+	StartTime      int64       `json:"start_time"`
+	EndTime        int64       `json:"end_time"`
+
+	outputPath string // S3 output path
+}
+
+type searchItem struct {
+	PK string `dynamo:"pk"` // Primary Key (Hash key) of DynamoDB
+	SK string `dynamo:"sk"` // Secondary Key (Range key) of DynamoDB
+
+	ID            searchID    `dynamo:"id"`
+	Status        queryStatus `dynamo:"status"`
+	Query         []query     `dynamo:"query"`
+	StartTime     time.Time   `dynamo:"start_time"`
+	EndTime       time.Time   `dynamo:"end_time"`
+	CreatedAt     *time.Time  `dynamo:"created_at"`
+	CompletedAt   *time.Time  `dynamo:"completed_at"`
+	AthenaQueryID string      `dynamo:"athena_query_id"`
+	RequestID     string      `dynamo:"request_id"`
+	OutputPath    string      `dynamo:"output_path"`
+	ScannedSize   int64       `dynamo:"scanned_size"`
+}
+
+func (x *searchItem) getElapsedSeconds() float64 {
+	if x.CreatedAt == nil {
+		return 0
+	}
+	if x.CompletedAt == nil {
+		return time.Now().UTC().Sub(*x.CreatedAt).Seconds()
+	}
+
+	return x.CompletedAt.Sub(*x.CreatedAt).Seconds()
+}
+
+type searchRepository interface {
+	put(*searchItem) error
+	get(searchID) (*searchItem, error)
+}
+
+type searchRepoDynamoDB struct {
+	region    string
+	tableName string
+}
+
+func searchIDtoKey(id searchID) string {
+	return "search:" + string(id)
+}
+
+func newSearchRepoDynamoDB(region, tableName string) *searchRepoDynamoDB {
+	return &searchRepoDynamoDB{
+		region:    region,
+		tableName: tableName,
+	}
+}
+
+func (x *searchRepoDynamoDB) put(item *searchItem) error {
+	db := dynamo.New(session.New(), &aws.Config{Region: aws.String(x.region)})
+	table := db.Table(x.tableName)
+
+	item.PK = searchIDtoKey(item.ID)
+	item.SK = "@"
+	if err := table.Put(item).Run(); err != nil {
+		return errors.Wrapf(err, "Fail to put searchItem: %v", *item)
+	}
+
+	return nil
+}
+
+func (x *searchRepoDynamoDB) get(id searchID) (*searchItem, error) {
+	db := dynamo.New(session.New(), &aws.Config{Region: aws.String(x.region)})
+	table := db.Table(x.tableName)
+
+	pk := searchIDtoKey(id)
+	sk := "@"
+	var item searchItem
+	if err := table.Get("pk", pk).Range("sk", dynamo.Equal, sk).One(&item); err != nil {
+		if err == dynamo.ErrNotFound {
+			return nil, nil
+		}
+
+		return nil, errors.Wrapf(err, "Fail to get searchItem: %s", id)
+	}
+
+	return &item, nil
+}

--- a/template.libsonnet
+++ b/template.libsonnet
@@ -589,6 +589,7 @@
               S3_BUCKET: DataS3Bucket,
               S3_PREFIX: DataS3Prefix,
               LOG_LEVEL: 'DEBUG',
+              SEARCH_TABLE_NAME: { Ref: 'SearchTable' },
             },
           },
           Events: {


### PR DESCRIPTION
- Use DynamoDB to store query meta data
- Use own searchID to identify search instead of Athena Query ID