### PR TITLE
Add ScannedSize to API response metadata

### DIFF
--- a/pkg/api/get_search.go
+++ b/pkg/api/get_search.go
@@ -46,8 +46,8 @@ func (x MinervaHandler) getMetaData(id searchID) (*searchMetaData, Error) {
 		StartTime:      item.StartTime.Unix(),
 		EndTime:        item.EndTime.Unix(),
 		SubmittedTime:  *item.CreatedAt,
-
-		outputPath: item.OutputPath,
+		ScannedSize:    item.ScannedSize,
+		outputPath:     item.OutputPath,
 	}, nil
 }
 

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -18,6 +18,7 @@ type searchMetaData struct {
 	Query          []Query     `json:"query"`
 	StartTime      int64       `json:"start_time"`
 	EndTime        int64       `json:"end_time"`
+	ScannedSize    int64       `json:"scanned_size"`
 
 	outputPath string // S3 output path
 }


### PR DESCRIPTION
Add ScannedSize into searchMetaData to calculate cost of query and display the cost on console.