### PR TITLE
Add minerva command as cli utility

### DIFF
--- a/cmd/minerva/common.go
+++ b/cmd/minerva/common.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/pkg/errors"
+)
+
+type arguments struct {
+	StackName string
+	Region    string
+}
+
+func (x arguments) describeStack() (map[string]*cloudformation.StackResource, error) {
+	ssn := session.New(&aws.Config{Region: aws.String(x.Region)})
+	client := cloudformation.New(ssn)
+
+	input := &cloudformation.DescribeStackResourcesInput{
+		StackName: aws.String(x.StackName),
+	}
+
+	output, err := client.DescribeStackResources(input)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Fail to DescribeStackResources for %v", x.StackName)
+	}
+
+	resources := map[string]*cloudformation.StackResource{}
+	for i := range output.StackResources {
+		rsc := output.StackResources[i]
+		resources[*rsc.LogicalResourceId] = rsc
+	}
+
+	return resources, nil
+}

--- a/cmd/minerva/main.go
+++ b/cmd/minerva/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	cli "github.com/urfave/cli/v2"
+)
+
+var logger = logrus.New()
+
+func main() {
+	var args arguments
+
+	app := &cli.App{
+		Name:  "minerva",
+		Usage: "CLI utility of minerva",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "stack-name",
+				Aliases:     []string{"s"},
+				Usage:       "StackName of CloudFormation",
+				Required:    true,
+				Destination: &args.StackName,
+			},
+			&cli.StringFlag{
+				Name:        "region",
+				Aliases:     []string{"r"},
+				Usage:       "AWS region",
+				Required:    true,
+				EnvVars:     []string{"AWS_REGION"},
+				Destination: &args.Region,
+			},
+		},
+		Commands: []*cli.Command{
+			mergeCommand(&args),
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		logger.WithError(err).Fatal("Abort")
+	}
+}

--- a/cmd/minerva/merge.go
+++ b/cmd/minerva/merge.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	cli "github.com/urfave/cli/v2"
+)
+
+type mergeArguments struct {
+	Begin string
+	End   string
+
+	beginTime time.Time
+	endTime   time.Time
+}
+
+type listParquetEvent struct {
+	BaseTime *time.Time `json:"base_time"`
+}
+
+func mergeAction(args arguments, mergeArgs mergeArguments) error {
+	if err := parseArguments(&mergeArgs); err != nil {
+		return err
+	}
+
+	resources, err := args.describeStack()
+	if err != nil {
+		return err
+	}
+
+	listObject := resources["listIndexObject"]
+
+	ssn := session.New(&aws.Config{Region: aws.String(args.Region)})
+	client := lambda.New(ssn)
+
+	for t := mergeArgs.beginTime; mergeArgs.endTime.After(t); t = t.Add(time.Hour) {
+		event := listParquetEvent{
+			BaseTime: &t,
+		}
+		raw, err := json.Marshal(event)
+		if err != nil {
+			return errors.Wrapf(err, "Fail to marshal listIndexObject event: %v", event)
+		}
+
+		input := &lambda.InvokeInput{
+			FunctionName: listObject.PhysicalResourceId,
+			Payload:      raw,
+		}
+		logger.WithFields(logrus.Fields{
+			"function": *listObject.PhysicalResourceId,
+			"payload":  string(raw),
+		}).Info("Invoke listIndexObject")
+
+		output, err := client.Invoke(input)
+		if err != nil {
+			return errors.Wrapf(err, "Fail to invoke listIndexObject: %v", *input)
+		}
+
+		logger.WithFields(logrus.Fields{
+			"response":   string(output.Payload),
+			"statusCode": aws.Int64Value(output.StatusCode),
+		}).Info("Done listIndexObject")
+	}
+
+	return nil
+}
+
+func mergeCommand(args *arguments) *cli.Command {
+	var mergeArgs mergeArguments
+
+	return &cli.Command{
+		Name:  "merge",
+		Usage: "Invoke merge process",
+		Action: func(c *cli.Context) error {
+			return mergeAction(*args, mergeArgs)
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "begin",
+				Aliases:     []string{"b"},
+				Usage:       "Begin time of merge (format: 2006-01-02T15:04:05)",
+				Required:    true,
+				Destination: &mergeArgs.Begin,
+			},
+			&cli.StringFlag{
+				Name:        "end",
+				Aliases:     []string{"e"},
+				Usage:       "End time of merge (format: 2006-01-02T15:04:05)",
+				Required:    true,
+				Destination: &mergeArgs.End,
+			},
+		},
+	}
+}
+
+func parseArguments(args *mergeArguments) error {
+	layout := "2006-01-02T15:04:05"
+	var err error
+
+	args.beginTime, err = time.Parse(layout, args.Begin)
+	if err != nil {
+		return errors.Wrapf(err, "Fail to parse begin time: %v", args.Begin)
+	}
+
+	args.endTime, err = time.Parse(layout, args.End)
+	if err != nil {
+		return errors.Wrapf(err, "Fail to parse end time: %v", args.End)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add minerva command. Only `merge` command is available for now.

## install

```
$ go get -u https://github.com/m-mizutani/minerva/cmd/minerva
```

## usage

```
$ minerva merge -s <your-stack-name> merge -b 2020-04-20T09:00:00 -e 2020-04-20T16:00:00
```

Then invoke `listIndexObject` and send merge queue(s) to `mergeIndexObject`